### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ implementation 'com.clevertap.android:clevertap-android-sdk:4.1.0'
 
 ```xml
 <service
-    android:name="com.clevertap.pushtemplates.PushTemplateMessagingService">
+    android:name="com.clevertap.pushtemplates.PushTemplateMessagingService"
+    android:exported="false">
     <intent-filter>
         <action android:name="com.google.firebase.MESSAGING_EVENT"/>
     </intent-filter>


### PR DESCRIPTION
Added android:exported="false" for com.clevertap.pushtemplates.PushTemplateMessagingService .

Adding android:exported is mandatory for all the services defined in manifest for Apps targeting Android 12 and higher .